### PR TITLE
通知用のURLを環境変数に入れる

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -26,10 +26,11 @@ class Server < Sinatra::Base
       an.notify!
     end
 
-    if ENV["SLACK_HOOK_URL"]
+    if ENV["SLACK_HOOK_URL"] and ENV['REVISION_URL']
       sn = SlackNotification.new(hook_url: ENV["SLACK_HOOK_URL"],
                                  app: params[:app],
                                  revision: params[:head_long],
+                                 revision_url: ENV["REVISION_URL"] + params[:head_long],
                                  git_log: params[:git_log])
       sn.notify!
     end

--- a/models/slack_notification.rb
+++ b/models/slack_notification.rb
@@ -2,19 +2,20 @@ require "json"
 
 class SlackNotification
   include ActiveModel::Validations
-  attr_reader :hook_url, :revision, :git_log, :app
+  attr_reader :hook_url, :revision_url, :revision, :git_log, :app
 
-  validates_presence_of :hook_url, :app, :revision, :git_log
+  validates_presence_of :hook_url, :app, :revision_url, :revision, :git_log
 
-  def initialize(hook_url:, app:, revision:, git_log:)
+  def initialize(hook_url:, app:, revision_url:, revision:, git_log:)
     @hook_url = hook_url
     @app = app
+    @revision_url = revision_url
     @revision = revision
     @git_log = git_log
   end
 
   def notify!
-    message = "#{app} is deployed in <https://github.com/ubiregiinc/ubiregi-server/commit/#{revision}|#{revision}> as:\n#{git_log}"
+    message = "#{app} is deployed in <#{revision_url}|#{revision}> as:\n#{git_log}"
     HTTPClient.new.post_content hook_url, { text: message }.to_json
   end
 end

--- a/test/all_test.rb
+++ b/test/all_test.rb
@@ -1,3 +1,4 @@
+$:.unshift File.dirname(__FILE__)
 require 'test_helper'
 
 require 'newrelic_notification_test'

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -14,6 +14,7 @@ class ControllerTest < TestCase
     ENV['AIRBRAKE_REPOSITORY'] = 'git@github.com:ubiregiinc/ping.git'
 
     ENV["SLACK_HOOK_URL"] = "https://example.com/hook"
+    ENV["REVISION_URL"] = "https://example.com/owner/repo/commit/"
   end
 
   def teardown
@@ -40,11 +41,11 @@ class ControllerTest < TestCase
       mock(n).notify!
     end
 
-    mock.proxy(SlackNotification).new(hook_url: "https://example.com/hook", app: "finger and register", revision: "testtest", git_log: "Git Log Message") do |n|
+    mock.proxy(SlackNotification).new(hook_url: "https://example.com/hook", app: "finger and register", revision_url: "https://example.com/owner/repo/commit/testtest", revision: "testtest", git_log: "Git Log Message") do |n|
       mock(n).notify!
     end
 
-    post '/notify', { "app" => "finger and register", "user" => "soutaro", "head_long" => "testtest", 'git_log' => "Git Log Message"}
+    post '/notify', { "app" => "finger and register", "user" => "soutaro", "revision_url" => "https://example.com/owner/repo/commit/testtest", "head_long" => "testtest", 'git_log' => "Git Log Message"}
 
     assert last_response.ok?
   end

--- a/test/slack_notification_test.rb
+++ b/test/slack_notification_test.rb
@@ -6,6 +6,7 @@ class SlackNotificationTest < TestCase
 
     @notification = SlackNotification.new(hook_url: "https://example.com/test",
                                           app: "ubiregi-server",
+                                          revision_url: "https://example.com/owner/repo/commit/130487dsfiguha",
                                           revision: "130487dsfiguha",
                                           git_log: "log message")
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,7 +4,7 @@ require 'rr'
 require 'unification_assertion'
 require 'rack/test'
 
-require 'app'
+require File.expand_path('app')
 
 MiniTest.autorun
 


### PR DESCRIPTION
Revision番号のリンクにつかうURLを環境変数から読み込むようにします。
#### 確認事項
- [ ] ローカルでテストした時にLoadErrorが発生したので対処したhttps://github.com/ubiregiinc/ping/commit/2f6f9bcffd8f7081fe6f003ddf4e897fb90b6d87 は必要かどうか

@soutaro 
